### PR TITLE
feature/documentacao-prds: automatiza publicação na wiki

### DIFF
--- a/.codex/docs/specs/ciclo-vida-autenticacao-credenciais/prd.md
+++ b/.codex/docs/specs/ciclo-vida-autenticacao-credenciais/prd.md
@@ -1,0 +1,124 @@
+# PRD: Ciclo de vida de autenticação e credenciais
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #214, #215, #224, #233
+
+## Contexto e problema
+
+Produção cria um administrador com credencial fixada no código; não há troca autenticada; o administrador inicial não é obrigado a trocar senha; JWTs continuam válidos após a troca; o encerramento de sessão limpa somente `localStorage` enquanto a sessão usa cookies.
+
+## Objetivo e métricas de sucesso
+
+Eliminar credenciais fixas e oferecer um ciclo de senha coerente. Sucesso: carga inicial insegura ausente; inicialização inválida falha antes de servir tráfego; primeiro acesso é restrito à troca; todo fluxo aplica a mesma política; troca/redefinição revoga tokens; encerramento de sessão remove todo o estado.
+
+## Usuários e jornadas
+
+Administrador configura a inicialização e troca a senha no primeiro acesso. Qualquer usuário autenticado altera a própria senha informando a atual. Usuário sem acesso usa recuperação. O encerramento de sessão elimina completamente a sessão.
+
+## Escopo
+
+### Incluído
+
+- Configuração do admin por ambiente e falha imediata.
+- Troca autenticada e troca obrigatória do admin seedado.
+- Política de 15–64+ caracteres e lista de bloqueio local.
+- Revogação global de tokens após qualquer troca/redefinição.
+- Encerramento de sessão centralizado para `doorKey`, `rankID`, `level` e dados de sessão.
+
+### Fora de escopo
+
+- MFA, SSO e painel geral de sessões.
+- Envio de senha a serviço externo de reputação.
+
+## Requisitos funcionais
+
+### RF-001 — Inicialização segura
+
+Produção deve exigir `Seed__AdminEmail` e `Seed__AdminPassword`, sem valores padrão secretos, e falhar claramente quando inválidos.
+
+### RF-002 — Primeiro acesso obrigatório
+
+O administrador criado pela carga inicial só pode acessar a jornada de troca até definir uma nova senha.
+
+### RF-003 — Alteração autenticada
+
+Usuário autenticado deve alterar senha mediante senha atual correta, nova senha e confirmação.
+
+### RF-004 — Política única
+
+Criação, alteração e recuperação devem validar no servidor mínimo 15, máximo suportado de ao menos 64, sem composição artificial, e rejeitar lista de bloqueio local.
+
+### RF-005 — Revogação e encerramento de sessão
+
+Qualquer mudança de senha invalida todos os tokens e exige nova autenticação; o encerramento de sessão remove todo o estado de autenticação sem apagar preferências não relacionadas.
+
+## Requisitos não funcionais
+
+### RNF-001 — Segurança e privacidade
+
+Senha nunca deve aparecer em código, registro, telemetria ou chamada externa; respostas não devem revelar credenciais.
+
+### RNF-002 — Consistência
+
+O backend é a autoridade da política; o frontend antecipa as mesmas mensagens e todos os pontos usam um único encerramento de sessão.
+
+## Critérios de aceitação
+
+### CA-001 — Configuração ausente (RF-001, RNF-001)
+
+- Dado um ambiente de produção sem variáveis válidas
+- Quando a aplicação inicia
+- Então aborta antes de servir requisições com mensagem clara sem expor senha
+
+### CA-002 — Primeiro acesso (RF-002)
+
+- Dado um administrador criado pela carga inicial com senha temporária
+- Quando autentica
+- Então só acessa troca obrigatória até concluí-la
+
+### CA-003 — Troca própria (RF-003, RF-004)
+
+- Dado um usuário autenticado
+- Quando informa senha atual correta e nova senha válida/confirmada
+- Então a senha é alterada; entradas inválidas retornam mensagem específica
+
+### CA-004 — Revogação (RF-005)
+
+- Dados tokens emitidos antes da mudança
+- Quando a senha muda por qualquer fluxo
+- Então todos são rejeitados e o usuário deve autenticar-se novamente
+
+### CA-005 — Encerramento de sessão (RF-005, RNF-002)
+
+- Dada uma sessão ativa
+- Quando o encerramento de sessão é acionado em qualquer tela
+- Então cookies e dados de sessão somem, preferências não relacionadas permanecem e rotas privadas ficam inacessíveis
+
+## Estratégia de validação
+
+xUnit para inicialização, política, troca e revogação; Vitest para formulário, encerramento de sessão e proteções de rota; Playwright para primeiro acesso, troca e nova autenticação.
+
+## Dependências e riscos
+
+Requer alteração persistida para senha temporária e versão de sessão, com migração/reversão. A inicialização deve distinguir um banco já inicializado da configuração obrigatória para criação.
+
+## Suposições
+
+- O admin inicial é o único usuário marcado para troca obrigatória pelo seed.
+- Cookies atuais permanecem lado cliente nesta entrega.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Config ausente | Fail-fast claro | Confirmado | Impede ambiente inseguro/inoperável |
+| Após troca | Revogar tudo e exigir nova autenticação | Confirmado | Exige controle de versão de sessão |
+| Política | 15–64+, sem composição/truncamento | Confirmado | Contrato comum servidor/cliente |
+| Senhas comuns | Lista de bloqueio local | Confirmado | Sem vazamento a terceiro |

--- a/.codex/docs/specs/contratos-dados-usuario/prd.md
+++ b/.codex/docs/specs/contratos-dados-usuario/prd.md
@@ -1,0 +1,112 @@
+# PRD: Cadastro e contratos de dados de usuário
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #216, #217, #218, #226
+
+## Contexto e problema
+
+O cadastro envia cidade fixa `Indefinido`, rejeita cursos curtos legítimos e os DTOs representam `DataIngresso` como `DateTime` ou `string`. Isso produz dados artificiais, datas inválidas e tratamentos especiais no frontend.
+
+## Objetivo e métricas de sucesso
+
+Estabelecer contrato previsível de usuário e cadastro. Sucesso: novos acadêmicos informam cidade real; `curso` aceita siglas de 2–100 caracteres; `DataIngresso` é data civil opcional ISO; campos equivalentes têm o mesmo tipo/formato em todos os endpoints afetados.
+
+## Usuários e jornadas
+
+Novos mentores/mentorados concluem cadastro com dados reais; administradores e usuários consultam perfil/listagens sem datas inválidas ou formatos divergentes.
+
+## Escopo
+
+### Incluído
+
+- Campo cidade no cadastro e validação backend/frontend.
+- Curso livre normalizado com 2–100 caracteres.
+- Padronização de DTOs, mapeamentos e interfaces frontend.
+- Exibição `Não informado` para cidade legada `Indefinido` e data ausente.
+
+### Fora de escopo
+
+- Catálogo/autocomplete de cursos.
+- Inferência ou migração automática de cidades legadas.
+
+## Requisitos funcionais
+
+### RF-001 — Cidade real
+
+Novo acadêmico deve informar uma cidade válida; o corpo da requisição não pode fabricar `Indefinido`.
+
+### RF-002 — Curso flexível
+
+Curso deve ser texto livre com trim, mínimo 2 e máximo 100, aceitando siglas.
+
+### RF-003 — Contrato consistente
+
+Campos compartilhados de usuário devem manter nomes, nulabilidade, enumerações e formatos equivalentes nos DTOs/endpoints.
+
+### RF-004 — Data civil e legado
+
+`DataIngresso` deve ser opcional, serializada `YYYY-MM-DD` e exibida `pt-BR`; valores ausentes e cidade `Indefinido` aparecem como `Não informado`.
+
+## Requisitos não funcionais
+
+### RNF-001 — Compatibilidade
+
+Mudanças de contrato devem ser documentadas e coordenadas com consumidores, sem converter ausência em dado falso.
+
+### RNF-002 — Validação autoritativa
+
+Backend valida regras; frontend replica feedback imediato e acessível.
+
+## Critérios de aceitação
+
+### CA-001 — Cadastro (RF-001, RF-002, RNF-002)
+
+- Dado um formulário acadêmico válido com cidade real e curso `ES`
+- Quando o cadastro é enviado
+- Então a API persiste os valores normalizados e não grava `Indefinido`
+
+### CA-002 — Entradas inválidas (RF-001, RF-002)
+
+- Dada uma cidade vazia ou um curso fora de 2–100 após trim
+- Quando a requisição chega diretamente à API
+- Então é rejeitada com erros de campo compreensíveis
+
+### CA-003 — Contratos e datas (RF-003, RF-004, RNF-001)
+
+- Dadas respostas de perfil, dependentes e responsáveis
+- Quando seus campos equivalentes são comparados
+- Então usam o mesmo contrato e data ISO ou `null`, exibida corretamente no cliente
+
+### CA-004 — Legado preservado (RF-004)
+
+- Dado um registro existente com cidade `Indefinido` ou data ausente
+- Quando é exibido
+- Então aparece `Não informado` sem alterar automaticamente o banco
+
+## Estratégia de validação
+
+Testes de contrato/mapeamento e serviço no backend; testes de esquema/formatação no frontend; E2E de cadastro e perfil.
+
+## Dependências e riscos
+
+Depende da infraestrutura de testes de qualidade. Alterar `DateTime` para semântica de data civil pode exigir conversor e coordenação; respostas devem ser caracterizadas antes da mudança.
+
+## Suposições
+
+- Cidade continua texto livre.
+- `DataIngresso` não representa horário/fuso.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Curso | Texto livre 2–100 | Confirmado | Sem catálogo nesta entrega |
+| Cidade legada | Preservar e exibir `Não informado` | Confirmado | Evita inventar dados |
+| DataIngresso | Data civil ISO opcional | Confirmado | Contrato uniforme |

--- a/.codex/docs/specs/experiencia-erros-frontend/prd.md
+++ b/.codex/docs/specs/experiencia-erros-frontend/prd.md
@@ -1,0 +1,105 @@
+# PRD: Experiência de erros no frontend
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issue relacionada: #225
+
+## Contexto e problema
+
+Telas e integrações exibem `Erro durante requisição` sem diferenciar validação, permissão, sessão, ausência, conflito, rede ou falha interna. O interceptor atual trata somente 401 e força navegação sem preservar contexto.
+
+## Objetivo e métricas de sucesso
+
+Padronizar mensagens acionáveis e comportamento por classe de erro. Sucesso: fluxos migrados não exibem mensagem genérica isolada; 401 e 403 têm efeitos distintos; detalhes técnicos ficam fora da UI de produção e podem ser correlacionados em diagnóstico.
+
+## Usuários e jornadas
+
+Usuário entende o problema e próximo passo; suporte distingue falha funcional de indisponibilidade sem expor dados sensíveis.
+
+## Escopo
+
+### Incluído
+
+- Modelo comum para 400/401/403/404/409/5xx, tempo limite/rede e erro desconhecido.
+- Mensagens contextualizadas por operação.
+- Preservação segura da rota pretendida após 401.
+- Migração das integrações/páginas com mensagens genéricas.
+
+### Fora de escopo
+
+- Plataforma externa de observabilidade.
+- Exibir rastreamento de pilha ou conteúdo técnico ao usuário.
+
+## Requisitos funcionais
+
+### RF-001 — Normalização
+
+Respostas e falhas de rede devem virar um erro de aplicação tipado com categoria, mensagem segura e identificador quando disponível.
+
+### RF-002 — Mensagem contextual
+
+Cada operação deve combinar categoria comum com contexto e ação sugerida, incluindo validações de campo.
+
+### RF-003 — Sessão versus permissão
+
+401 deve limpar a sessão e ir à autenticação preservando uma rota segura; 403 mantém a sessão e informa falta de permissão.
+
+## Requisitos não funcionais
+
+### RNF-001 — Privacidade
+
+A interface e os registros de produção não devem expor token, senha, rastreamento de pilha ou resposta sensível.
+
+### RNF-002 — Consistência e acessibilidade
+
+Mensagens devem usar componente acessível comum e vocabulário estável.
+
+## Critérios de aceitação
+
+### CA-001 — Categorias (RF-001, RF-002)
+
+- Dadas respostas 400, 403, 404, 409, 500 e uma falha de rede
+- Quando uma operação migrada falha
+- Então a mensagem identifica contexto e próximo passo sem detalhes sensíveis
+
+### CA-002 — 401 (RF-003, RNF-001)
+
+- Dada uma sessão expirada em rota privada
+- Quando a API retorna 401
+- Então a sessão é limpa, a tela de autenticação é aberta e a rota segura pode ser retomada após autenticação
+
+### CA-003 — 403 (RF-003)
+
+- Dada uma sessão válida sem permissão
+- Quando a API retorna 403
+- Então a sessão permanece e o usuário recebe aviso de autorização
+
+### CA-004 — Acessibilidade (RNF-002)
+
+- Dada uma mensagem exibida
+- Quando tecnologia assistiva observa a página
+- Então o feedback é anunciado e pode ser associado à ação/campo
+
+## Estratégia de validação
+
+Vitest para normalizador/interceptor e estados de página; MSW para respostas; Playwright para 401/403 e retorno pós-autenticação.
+
+## Dependências e riscos
+
+Depende de encerramento de sessão centralizado e infraestrutura de testes do frontend. As APIs hoje retornam textos heterogêneos; compatibilizar sem exigir migração simultânea de todos os endpoints.
+
+## Suposições
+
+- A rota pretendida só é guardada se interna e autorizável.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| 401/403 | 401 encerra; 403 preserva sessão | Confirmado | Evita logoff por autorização |

--- a/.codex/docs/specs/frontend-responsivo/prd.md
+++ b/.codex/docs/specs/frontend-responsivo/prd.md
@@ -1,0 +1,98 @@
+# PRD: Frontend responsivo
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #229, #230, #231
+
+## Contexto e problema
+
+O cadastro usa `w-[750px]` e grade fixo; tabelas globais usam flex horizontal e larguras inline. Em mobile, listagens como produtos ultrapassam o viewport e exigem rolagem lateral.
+
+## Objetivo e métricas de sucesso
+
+Eliminar overflow horizontal normal entre 320 px e desktop e criar padrão reutilizável: cards abaixo de `md`, tabela/lista a partir de `md`. Cadastro e ações devem permanecer legíveis, operáveis por teclado e sem regressão desktop.
+
+## Usuários e jornadas
+
+Usuários em celular cadastram conta, consultam produtos e acionam linhas; usuários desktop mantêm densidade e navegação atuais.
+
+## Escopo
+
+### Incluído
+
+- Primitivas globais Header/Item/ItemClickable/ItemOnly/TableItemWithActions e variantes usadas.
+- Busca/listagem de produtos e cadastro de conta.
+- Estados vazio, carregamento, conteúdo longo e ações em 320/375/768/desktop.
+
+### Fora de escopo
+
+- Redesign visual de módulos não consumidores das primitivas.
+- Aplicativo nativo.
+
+## Requisitos funcionais
+
+### RF-001 — Padrão adaptativo
+
+Listagens devem renderizar cards rotulados abaixo de `md` e modo tabular a partir de `md`, preservando dados prioritários e ações.
+
+### RF-002 — Cadastro adaptativo
+
+O formulário deve usar largura fluida, uma coluna em telas pequenas e duas quando houver espaço.
+
+### RF-003 — Migração de consumidores
+
+Busca de produtos e consumidores globais afetados devem adotar a primitiva sem correções pontuais incompatíveis.
+
+## Requisitos não funcionais
+
+### RNF-001 — Viewport e acessibilidade
+
+Não deve haver scroll horizontal da página em 320 px; foco, ordem de leitura, nomes de ações e contraste permanecem acessíveis.
+
+### RNF-002 — Compatibilidade desktop
+
+Desktop/tablet preservam conteúdo, ações e densidade funcional.
+
+## Critérios de aceitação
+
+### CA-001 — Cards mobile (RF-001, RNF-001)
+
+- Dado um viewport abaixo de `md` e conteúdo longo
+- Quando uma listagem é exibida
+- Então cada registro aparece como card rotulado, ações são alcançáveis e a página não transborda horizontalmente
+
+### CA-002 — Cadastro mobile (RF-002, RNF-001)
+
+- Dado um viewport de 320 px
+- Quando a conta é preenchida
+- Então campos e botões cabem em uma coluna sem corte ou scroll lateral
+
+### CA-003 — Desktop (RF-001, RF-003, RNF-002)
+
+- Dado um viewport a partir de `md`
+- Quando listagens e cadastro são usados
+- Então o modo tabular/grade mantém todos os dados e ações
+
+## Estratégia de validação
+
+Vitest/RTL para variantes e acessibilidade; Playwright em viewports 320, 375, 768 e desktop, incluindo overflow e interações.
+
+## Dependências e riscos
+
+Depende da infraestrutura de testes do frontend. Variantes de tabela têm funções de retorno distintas; migrar por consumidor e caracterizar ações antes de consolidar.
+
+## Suposições
+
+- Breakpoint `md` do Tailwind permanece o divisor.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Estratégia mobile | Cards abaixo de `md` | Confirmado | Remove overflow com rótulos explícitos |

--- a/.codex/docs/specs/fundacao-qualidade-testes/prd.md
+++ b/.codex/docs/specs/fundacao-qualidade-testes/prd.md
@@ -1,0 +1,102 @@
+# PRD: Fundação de qualidade e testes críticos
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #227, #237
+
+## Contexto e problema
+
+Os fluxos críticos têm cobertura insuficiente e os sinais de manutenibilidade/confiabilidade não possuem linha de base reproduzível. Hoje há quatro testes xUnit, um deles falha, `backend/backend.sln` não inclui `Tests.csproj`, o frontend não possui executor de testes e o lint de `src` reporta 21.845 avisos.
+
+## Objetivo e métricas de sucesso
+
+Criar validações pré-merge reproduzíveis e uma pirâmide mínima de testes. Sucesso: 100% das validações definidas executam em PR para `develop`; fluxos críticos selecionados têm casos positivos e negativos; achados altos da linha de base são corrigidos ou bloqueiam merge; médios/baixos viram uma lista de pendências rastreável.
+
+## Usuários e jornadas
+
+Mantenedores executam validações localmente e em CI; usuários finais ganham proteção contra regressões em autenticação, cadastro/aprovação, senha e empréstimos.
+
+## Escopo
+
+### Incluído
+
+- Corrigir/estabilizar a infraestrutura de testes xUnit e incluí-la na solução.
+- Adicionar Vitest/Testing Library e Playwright.
+- Criar linha de base por módulo para maintainability/reliability e corrigir achados altos.
+- Adicionar CI pré-merge para `develop`.
+
+### Fora de escopo
+
+- Zerar todos os avisos históricos em um único ciclo.
+- Cobertura integral do produto ou refatorações sem achado mensurável.
+
+## Requisitos funcionais
+
+### RF-001 — Suíte crítica reproduzível
+
+O time deve executar testes automatizados de sucesso e erro para autenticação, cadastro/aprovação, recuperação/troca de senha e empréstimos.
+
+### RF-002 — Linha de base acionável
+
+O repositório deve produzir um inventário por módulo/severidade, corrigir achados altos e registrar uma lista de pendências para os demais.
+
+### RF-003 — Validação pré-merge
+
+PRs para `develop` devem executar lint, compilação e testes afetados antes do merge.
+
+## Requisitos não funcionais
+
+### RNF-001 — Reprodutibilidade
+
+Os comandos locais e de CI devem usar versões fixadas em manifestos/arquivos de bloqueio e produzir o mesmo resultado.
+
+### RNF-002 — Tempo e diagnóstico
+
+Falhas devem identificar suíte e cenário; jobs independentes devem executar em paralelo quando não compartilham estado.
+
+## Critérios de aceitação
+
+### CA-001 — Fluxos críticos (RF-001)
+
+- Dado um checkout limpo
+- Quando as suítes xUnit, Vitest e Playwright são executadas
+- Então os cenários críticos definidos apresentam resultados determinísticos e falhas acionáveis
+
+### CA-002 — Qualidade priorizada (RF-002, RNF-002)
+
+- Dada a linha de base coletada
+- Quando os achados são classificados
+- Então todos os altos são corrigidos ou explicitamente bloqueiam a conclusão, e os médios/baixos possuem uma lista de pendências
+
+### CA-003 — Proteção de develop (RF-003, RNF-001)
+
+- Dado um PR destinado a `develop`
+- Quando código afetado é enviado
+- Então as validações relevantes executam antes da possibilidade de merge
+
+## Estratégia de validação
+
+Caracterizar primeiro os quatro testes existentes e a linha de base do lint; observar RED nos novos cenários, GREEN pela menor mudança e REFACTOR com as mesmas suítes. Validar o fluxo de trabalho por lint/sintaxe e PR de teste.
+
+## Dependências e riscos
+
+Depende de ambiente E2E isolado e dados determinísticos. O volume de avisos pode esconder sinais reais; a validação deve impedir novas violações enquanto a lista de pendências histórica é reduzida.
+
+## Suposições
+
+- Playwright cobrirá somente essenciais crítico neste ciclo.
+- Achados altos serão definidos pela ferramenta escolhida e evidência reproduzível.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Alcance de #237 | Linha de base + altos; lista de pendências para os demais | Confirmado | Evita refatoração global não verificável |
+| Pirâmide | xUnit + Vitest/RTL + Playwright essenciais | Confirmado | Exige infraestrutura de testes frontend/E2E |
+| CI | Validar PR para `develop`; entrega em `main` | Confirmado | Separa CI de lançamento |

--- a/.codex/docs/specs/manual-usuario/prd.md
+++ b/.codex/docs/specs/manual-usuario/prd.md
@@ -1,0 +1,98 @@
+# PRD: Manual de uso do LabOn
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issue relacionada: #220
+
+## Contexto e problema
+
+Não há manual funcional suficiente para novos administradores, mentores e mentorados; integração inicial, homologação e suporte dependem de orientação informal.
+
+## Objetivo e métricas de sucesso
+
+Permitir que uma pessoa nova execute os principais fluxos apenas com a documentação. A fonte deve ser revisada em `docs/manual/` e publicada na Wiki, cobrindo três perfis, acesso, cadastro/aprovação, senha, solicitações/empréstimos e configuração inicial.
+
+## Usuários e jornadas
+
+Administrador configura e opera; mentor gerencia vínculos e empréstimos; mentorado consulta e acompanha; suporte aponta seções estáveis.
+
+## Escopo
+
+### Incluído
+
+- Visão geral, perfis/permissões, primeiro acesso, autenticação, cadastro/aprovação, senhas e operações por perfil.
+- Capturas sem dados pessoais/segredos e texto alternativo.
+- Fonte no repositório e publicação/sincronização na Wiki.
+
+### Fora de escopo
+
+- Documentação interna de arquitetura/API.
+- Descrever recursos ocultos ou ainda não entregues.
+
+## Requisitos funcionais
+
+### RF-001 — Manual por jornada
+
+O manual deve cobrir pré-requisitos, passos, resultado esperado, erros comuns e saída segura para cada jornada principal.
+
+### RF-002 — Perfis e permissões
+
+Cada seção deve indicar quem pode executar a ação e quais opções aparecem.
+
+### RF-003 — Publicação rastreável
+
+A fonte versionada deve ser publicável na Wiki sem divergência silenciosa.
+
+## Requisitos não funcionais
+
+### RNF-001 — Acessibilidade e privacidade
+
+Imagens têm texto alternativo e não exibem credenciais/dados pessoais; linguagem é clara e navegável.
+
+### RNF-002 — Manutenibilidade
+
+Links e instruções devem ser verificáveis; versão/data e responsável de revisão ficam visíveis.
+
+## Critérios de aceitação
+
+### CA-001 — Autonomia (RF-001, RF-002)
+
+- Dado um usuário novo de qualquer perfil
+- Quando segue o manual
+- Então conclui as operações principais sem orientação informal
+
+### CA-002 — Conteúdo seguro (RNF-001)
+
+- Dada uma revisão das páginas e imagens
+- Quando privacidade/acessibilidade são auditadas
+- Então não há segredo/PII e toda imagem informativa possui alternativa textual
+
+### CA-003 — Fonte e Wiki (RF-003, RNF-002)
+
+- Dada uma mudança aprovada em `docs/manual/`
+- Quando o processo de publicação executa
+- Então a Wiki reflete a mesma versão e links passam na verificação
+
+## Estratégia de validação
+
+Checklist por jornada/perfil, link checker e teste de tarefa com pessoa sem contexto; comparação entre fonte e Wiki após publicação.
+
+## Dependências e riscos
+
+Deve ser finalizado depois dos slugs que alteram UX/autenticação/contratos. Publicar Wiki exige permissão externa e não ocorre automaticamente neste plano.
+
+## Suposições
+
+- A Wiki continuará habilitada.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Fonte | `docs/manual/` + publicação na Wiki | Confirmado | Revisão junto ao produto |

--- a/.codex/docs/specs/modernizacao-esteira-conteineres/prd.md
+++ b/.codex/docs/specs/modernizacao-esteira-conteineres/prd.md
@@ -1,0 +1,112 @@
+# PRD: Modernização da esteira de contêineres
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #234, #235, #238
+
+## Contexto e problema
+
+Os fluxos de trabalho de frontend/backend rodam após um PR fechado em `main`, usam Docker Scout com autenticação no Docker Hub, fazem uma implantação indesejada na Azure e publicam somente uma arquitetura.
+
+## Objetivo e métricas de sucesso
+
+Separar validação de entrega, remover Azure/Scout/Docker Hub e publicar no GHCR manifestos `linux/amd64` + `linux/arm64`. Sucesso: ambas as plataformas constam nas tags versionada e `latest`; Trivy bloqueia risco corrigível definido; não restam etapas ou referências operacionais obsoletas.
+
+## Usuários e jornadas
+
+Mantenedores recebem retorno pré-merge; operadores consomem a mesma tag em AMD64 ou ARM64; a equipe de segurança consulta registros e SARIF.
+
+## Escopo
+
+### Incluído
+
+- CI em PR para `develop` e entrega em merge para `main`/dispatch autorizado.
+- Buildx/QEMU, manifestos multi-arch e push GHCR.
+- Trivy com registro e SARIF.
+- Remoção de Azure Container Apps, Docker Scout e autenticação no Docker Hub exclusiva da varredura.
+
+### Fora de escopo
+
+- Novo provedor de implantação.
+- Plataformas além de `linux/amd64` e `linux/arm64`.
+
+## Requisitos funcionais
+
+### RF-001 — Entrega multi-arch
+
+Frontend e backend devem publicar manifestos únicos para AMD64/ARM64 nas tags versionada e `latest`.
+
+### RF-002 — Varredura com Trivy
+
+A esteira deve exibir relatório, publicar SARIF e falhar para `CRITICAL` ou `HIGH` com correção disponível.
+
+### RF-003 — Remover integrações obsoletas
+
+Os fluxos de trabalho não devem autenticar/implantar na Azure nem depender do Docker Hub/Scout para varredura.
+
+### RF-004 — Separar CI e lançamento
+
+PRs para `develop` validam; publicação/lançamento ocorre em promoção para `main` ou dispatch autorizado.
+
+## Requisitos não funcionais
+
+### RNF-001 — Compatibilidade de tags
+
+Consumidores atuais de tags GHCR devem continuar funcionando sem escolher sufixo de arquitetura.
+
+### RNF-002 — Menor privilégio
+
+Cada trabalho deve declarar somente as permissões necessárias e não expor segredos em registros.
+
+## Critérios de aceitação
+
+### CA-001 — Manifesto (RF-001, RNF-001)
+
+- Dada uma entrega concluída
+- Quando o manifesto GHCR é inspecionado
+- Então contém exatamente `linux/amd64` e `linux/arm64` nas duas imagens e tags esperadas
+
+### CA-002 — Política Trivy (RF-002)
+
+- Dada uma imagem com vulnerabilidade bloqueante corrigível
+- Quando o varredura executa
+- Então o job falha, mostra relatório e publica SARIF
+
+### CA-003 — Limpeza (RF-003, RNF-002)
+
+- Dados os fluxos de trabalho atualizados
+- Quando são auditados
+- Então não há ações/segredos referenciados de Azure, Docker Scout ou autenticação no Docker Hub da varredura
+
+### CA-004 — Eventos (RF-004)
+
+- Dado um PR para `develop` e uma promoção para `main`
+- Quando cada evento ocorre
+- Então o primeiro apenas valida e o segundo pode publicar/lançamento
+
+## Estratégia de validação
+
+Lint de YAML/actions, compilação local por plataforma quando disponível, inspeção com `docker buildx imagetools inspect` e cenário controlado para política Trivy.
+
+## Dependências e riscos
+
+Depende das validações do slug de qualidade. ARM pode falhar por artefato nativo; `latest` só deve avançar após todas as plataformas e varreduras passarem.
+
+## Suposições
+
+- GHCR permanece registry oficial.
+- Secrets obsoletos nas configurações do GitHub serão removidos manualmente após confirmar ausência de consumidores.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Tags ARM | Manifesto único AMD64/ARM64 | Confirmado | Mantém compatibilidade |
+| Varredura | Registro + SARIF; bloquear alto/crítico corrigível | Confirmado | Diagnóstico e validação |
+| Eventos | CI em `develop`, lançamento em `main` | Confirmado | Proteção pré-merge |

--- a/.codex/docs/specs/navegacao-pos-autenticacao/prd.md
+++ b/.codex/docs/specs/navegacao-pos-autenticacao/prd.md
@@ -1,0 +1,99 @@
+# PRD: Navegação e experiência pós-autenticação
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #219, #221, #222, #223
+
+## Contexto e problema
+
+A tela comum pós-autenticação usa conteúdo visual sem propósito claro; jornadas por perfil não priorizam ações; a tela de histórico de solicitação falha; ações “Voltar” podem encerrar a sessão ou levar a um destino incorreto.
+
+## Objetivo e métricas de sucesso
+
+Dar a cada perfil uma entrada operacional e navegação determinística. Sucesso: nenhuma ação de retorno limpa sessão; histórico administrativo carrega ou mostra erro contextual; home não contém carrossel; atalhos exibidos respeitam permissões.
+
+## Usuários e jornadas
+
+Administrador acessa gestão/aprovações/históricos; mentor acessa turma, solicitações e empréstimos; mentorado acessa busca, histórico e perfil.
+
+## Escopo
+
+### Incluído
+
+- Homes por perfil com atalhos funcionais.
+- Remoção do carrossel.
+- Correção do histórico de solicitação administrativo.
+- Rotas-pai explícitas para voltar, inclusive acesso direto/refresh.
+
+### Fora de escopo
+
+- Novos módulos de negócio ou dashboard analítico.
+
+## Requisitos funcionais
+
+### RF-001 — Home por perfil
+
+Após a autenticação, cada perfil deve ver somente atalhos autorizados e funcionais, sem carrossel decorativo.
+
+### RF-002 — Histórico administrativo
+
+A jornada de histórico deve chamar contrato válido, tratar vazio/erro e manter autenticação.
+
+### RF-003 — Retorno determinístico
+
+Cada ação “Voltar” deve apontar para a rota-pai explícita do módulo/perfil e nunca encerrar a sessão.
+
+## Requisitos não funcionais
+
+### RNF-001 — Autorização
+
+Atalhos e rotas devem respeitar as mesmas permissões no frontend e API; ocultação não substitui autorização.
+
+### RNF-002 — Previsibilidade
+
+Acesso direto, refresh e retorno devem produzir o mesmo destino seguro.
+
+## Critérios de aceitação
+
+### CA-001 — Entrada por perfil (RF-001, RNF-001)
+
+- Dado um usuário autenticado em um dos três perfis
+- Quando entra na home
+- Então vê apenas ações operacionais autorizadas e nenhum carrossel
+
+### CA-002 — Histórico (RF-002)
+
+- Dado um administrador autorizado
+- Quando abre histórico de solicitação
+- Então dados ou estado vazio carregam sem erro genérico e a sessão permanece ativa
+
+### CA-003 — Voltar (RF-003, RNF-002)
+
+- Dada uma tela autenticada aberta por link direto ou navegação interna
+- Quando “Voltar” é acionado
+- Então navega para a rota-pai definida sem remover credenciais
+
+## Estratégia de validação
+
+Caracterização de rotas e integrações; Vitest para mapas por perfil e botões; Playwright para autenticação, acesso direto, histórico e retorno.
+
+## Dependências e riscos
+
+Depende do encerramento de sessão centralizado e do tratamento de erros. A rota `mentor/history/mentee` atualmente aponta para `LoanCreation`, indicando possível configuração incorreta a caracterizar.
+
+## Suposições
+
+- Os atalhos usam apenas rotas já funcionais.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Home | Remover carrossel e priorizar ações por perfil | Confirmado | UX funcional |
+| Voltar | Rota-pai explícita | Confirmado | Não depende do histórico do navegador |

--- a/.codex/docs/specs/remediacao-vulnerabilidades-dependencias/prd.md
+++ b/.codex/docs/specs/remediacao-vulnerabilidades-dependencias/prd.md
@@ -1,0 +1,99 @@
+# PRD: Remediação de vulnerabilidades de dependências
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issue relacionada: #236
+
+## Contexto e problema
+
+O Dependabot apresenta 99 alertas abertos na consulta de 2026-08-04, majoritariamente npm, e a restauração do .NET sinaliza o AutoMapper 14.0.0 com vulnerabilidade alta. Dependências vulneráveis e possivelmente não utilizadas ampliam a superfície de ataque.
+
+## Objetivo e métricas de sucesso
+
+Eliminar todos os alertas críticos/altos com correção disponível, remover dependências diretas sem uso e documentar risco/mitigação para casos sem correção. Médios/baixos devem ser atualizados em lotes seguros ou registrados em uma lista de pendências.
+
+## Usuários e jornadas
+
+Mantenedores recebem builds seguros e previsíveis; operadores deixam de distribuir componentes com vulnerabilidades conhecidas corrigíveis.
+
+## Escopo
+
+### Incluído
+
+- Inventário npm/NuGet direto e transitivo.
+- Remoção de dependências sem uso e upgrades em lotes compatíveis.
+- Validação de compilação, testes e alertas após cada lote.
+
+### Fora de escopo
+
+- Migração funcional ampla apenas para encerrar alerta médio/baixo.
+- Supressão sem justificativa, prazo e responsável.
+
+## Requisitos funcionais
+
+### RF-001 — Inventariar e priorizar
+
+Cada alerta deve ser ligado à dependência raiz, severidade, versão corrigida e impacto.
+
+### RF-002 — Remediar risco prioritário
+
+Alertas críticos/altos corrigíveis devem ser eliminados e dependências diretas sem uso removidas.
+
+### RF-003 — Tratar exceções
+
+Alertas sem correção devem ter mitigação, risco residual, responsável e revisão; as demais severidades devem ter lote ou registro na lista de pendências.
+
+## Requisitos não funcionais
+
+### RNF-001 — Compatibilidade
+
+Cada lote deve preservar compilação e comportamento coberto por testes.
+
+### RNF-002 — Auditabilidade
+
+Arquivos de bloqueio e evidências de antes/depois devem permitir reproduzir a redução dos alertas.
+
+## Critérios de aceitação
+
+### CA-001 — Inventário (RF-001, RNF-002)
+
+- Dados os alertas abertos
+- Quando o inventário é produzido
+- Então todo crítico/alto aponta dependência raiz, correção e lote
+
+### CA-002 — Prioridade zerada (RF-002, RNF-001)
+
+- Dados alertas críticos/altos com correção
+- Quando os lotes são concluídos
+- Então não resta alerta corrigível nessas severidades e compilação/testes passam
+
+### CA-003 — Risco explícito (RF-003)
+
+- Dado um alerta não corrigido
+- Quando o slug é encerrado
+- Então existe justificativa, mitigação, responsável e prazo de revisão
+
+## Estratégia de validação
+
+Capturar `npm audit`, `dotnet list package --vulnerable --include-transitive` e Dependabot antes/depois; executar testes direcionados por lote e validações amplos ao final.
+
+## Dependências e riscos
+
+Depende de `quality-and-test-foundation` para reduzir risco de upgrades. Atualizações major devem ser divididas e podem exigir adaptação de API.
+
+## Suposições
+
+- O total de 99 alertas é um retrato e pode mudar.
+- Credenciais atuais permitem leitura, mas não encerramento manual de alertas por supressão.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Limite inicial | Zerar críticos/altos corrigíveis; lotear demais | Confirmado | Prioriza risco e compatibilidade |

--- a/.codex/docs/specs/visibilidade-posicionamento-funcionalidades/prd.md
+++ b/.codex/docs/specs/visibilidade-posicionamento-funcionalidades/prd.md
@@ -1,0 +1,98 @@
+# PRD: Visibilidade e posicionamento de funcionalidades
+
+- Status: pronto
+- Responsável: não definido
+- Atualizado em: 2026-08-04
+- Validação de descoberta: confirmada
+- Issues relacionadas: #228, #232
+
+## Contexto e problema
+
+Itens como `Labon Pro (em breve)`, páginas `UnderDevelopment` e importação de planilha aparecem em jornadas de produção sem entrega funcional ou em contexto inadequado.
+
+## Objetivo e métricas de sucesso
+
+Fazer a interface prometer apenas capacidades operacionais. Sucesso: nenhum recurso incompleto é alcançável na navegação de produção; rotas/ações órfãs são removidas; uma futura importação só reaparece em gestão de produtos com contrato ponta a ponta.
+
+## Usuários e jornadas
+
+Usuários finais navegam sem placeholders; administradores não encontram importação quebrada na conta.
+
+## Escopo
+
+### Incluído
+
+- Inventário de itens “em breve”, indisponíveis e `UnderDevelopment` alcançáveis.
+- Remoção de entradas, rotas e imports mortos na produção.
+- Remoção da importação da tela de conta.
+
+### Fora de escopo
+
+- Implementar Labon Pro ou importação de planilha.
+- Criar infraestrutura de sinalizadores de funcionalidade.
+
+## Requisitos funcionais
+
+### RF-001 — Ocultar incompletos
+
+Funcionalidades não operacionais não devem aparecer nem ser alcançáveis em produção.
+
+### RF-002 — Conta coerente
+
+A tela de conta não deve conter importação de bens; futura entrega deve pertencer ao módulo de produtos.
+
+### RF-003 — Limpeza segura
+
+Remoção visual deve incluir rotas/imports sem uso sem afetar funcionalidades prontas.
+
+## Requisitos não funcionais
+
+### RNF-001 — Clareza
+
+Textos e ações exibidos devem descrever capacidades disponíveis agora.
+
+### RNF-002 — Manutenibilidade
+
+Não devem restar caminhos mortos ou avisos novos após a remoção.
+
+## Critérios de aceitação
+
+### CA-001 — Produção sem placeholders (RF-001, RNF-001)
+
+- Dada uma compilação de produção
+- Quando menus, homes e rotas públicas/autenticadas são percorridos
+- Então não há item “em breve”, placeholder alcançável ou ação sem comportamento
+
+### CA-002 — Importação (RF-002)
+
+- Dada uma conta de administrador
+- Quando a página de perfil/conta abre
+- Então a importação de bens não aparece
+
+### CA-003 — Limpeza (RF-003, RNF-002)
+
+- Dados os itens removidos
+- Quando lint, compilação e testes executam
+- Então não restam imports/rotas mortos nem regressões
+
+## Estratégia de validação
+
+Busca estática por textos/componentes, testes de navegação/rotas em Vitest e essenciais Playwright de menus por perfil.
+
+## Dependências e riscos
+
+Pode revelar links diretos usados informalmente; inventariar antes de excluir rota.
+
+## Suposições
+
+- Nenhum recurso incompleto precisa ser preservado em ambiente de desenvolvimento nesta entrega.
+
+## Perguntas abertas
+
+Nenhuma bloqueante.
+
+## Decisões da validação de descoberta
+
+| Decisão | Recomendação | Resposta confirmada | Impacto |
+|---|---|---|---|
+| Exposição | Remover da produção até entrega completa | Confirmado | Sem sinalizadores de funcionalidade agora |

--- a/.github/scripts/sync_prds_to_wiki.py
+++ b/.github/scripts/sync_prds_to_wiki.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Publish versioned PRDs as deterministic GitHub Wiki pages."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+SLUG_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+TITLE_PATTERN = re.compile(r"^#\s+PRD:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def metadata(content: str, label: str, fallback: str = "—") -> str:
+    match = re.search(rf"^-\s+{re.escape(label)}:\s*(.+?)\s*$", content, re.MULTILINE)
+    return match.group(1).strip() if match else fallback
+
+
+def prd_slugs(source: Path) -> list[str]:
+    return sorted(
+        directory.name
+        for directory in source.iterdir()
+        if directory.is_dir() and (directory / "prd.md").is_file()
+    )
+
+
+def publish(source: Path, wiki: Path, repository: str, ref: str) -> int:
+    if not source.is_dir():
+        raise FileNotFoundError(f"Diretório de PRDs não encontrado: {source}")
+    if not wiki.is_dir():
+        raise FileNotFoundError(f"Diretório da wiki não encontrado: {wiki}")
+
+    slugs = prd_slugs(source)
+    if not slugs:
+        raise RuntimeError(f"Nenhum PRD encontrado em {source}")
+
+    for old_page in wiki.glob("PRD-*.md"):
+        old_page.unlink()
+
+    rows: list[str] = []
+    for slug in slugs:
+        if not SLUG_PATTERN.fullmatch(slug):
+            raise ValueError(f"Slug inválido para página da wiki: {slug}")
+
+        prd_path = source / slug / "prd.md"
+        content = prd_path.read_text(encoding="utf-8-sig").strip()
+        title_match = TITLE_PATTERN.search(content)
+        if not title_match:
+            raise ValueError(f"Título '# PRD:' não encontrado em {prd_path}")
+
+        title = title_match.group(1).strip()
+        status = metadata(content, "Status")
+        updated = metadata(content, "Atualizado em")
+        source_url = (
+            f"https://github.com/{repository}/blob/{ref}/"
+            f".codex/docs/specs/{slug}/prd.md"
+        )
+        notice = (
+            "<!-- Página gerada automaticamente. Edite o PRD no repositório principal. -->\n\n"
+            f"> Documento publicado automaticamente a partir do "
+            f"[PRD versionado no repositório principal]({source_url}).\n\n"
+        )
+        (wiki / f"PRD-{slug}.md").write_text(
+            notice + content + "\n", encoding="utf-8", newline="\n"
+        )
+        rows.append(f"| [{title}](PRD-{slug}) | {status} | {updated} |")
+
+    index = "\n".join(
+        [
+            "# Product Requirements Document (PRD)",
+            "",
+            "Esta página reúne os documentos de requisitos do produto do LabOn. "
+            "As páginas são publicadas automaticamente a partir dos PRDs versionados "
+            "no repositório principal.",
+            "",
+            "| PRD | Status | Atualizado em |",
+            "| --- | --- | --- |",
+            *rows,
+            "",
+            "<!-- Índice gerado automaticamente. -->",
+            "",
+        ]
+    )
+    (wiki / "Product-Requirements-Document-(PRD).md").write_text(
+        index, encoding="utf-8", newline="\n"
+    )
+    return len(slugs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--wiki", type=Path, required=True)
+    parser.add_argument("--repository", default="ifpebj-ti/lab-solos")
+    parser.add_argument("--ref", default="main")
+    args = parser.parse_args()
+
+    count = publish(args.source, args.wiki, args.repository, args.ref)
+    print(f"{count} PRD(s) publicado(s) na wiki.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/sync_prds_to_wiki.py
+++ b/.github/scripts/sync_prds_to_wiki.py
@@ -25,11 +25,18 @@ def prd_slugs(source: Path) -> list[str]:
     )
 
 
-def demote_headings(content: str) -> str:
-    """Move source headings one level down so each PRD fits under the wiki page."""
+def format_prd_content(content: str) -> str:
+    """Keep only the PRD title in the wiki outline."""
+
+    def replace_heading(match: re.Match[str]) -> str:
+        level, title = match.groups()
+        if level == "#":
+            return f"## {title}"
+        return f"**{title}**"
+
     return re.sub(
-        r"^(#{1,5})(\s+)",
-        lambda match: f"#{match.group(1)}{match.group(2)}",
+        r"^(#{1,6})[ \t]+(.+?)[ \t]*$",
+        replace_heading,
         content,
         flags=re.MULTILINE,
     )
@@ -74,7 +81,7 @@ def publish(source: Path, wiki: Path, repository: str, ref: str) -> int:
                     "",
                     f'<a id="prd-{slug}"></a>',
                     "",
-                    demote_headings(content),
+                    format_prd_content(content),
                     "",
                     f"> Fonte: [PRD versionado no repositório principal]({source_url}).",
                 ]

--- a/.github/scripts/sync_prds_to_wiki.py
+++ b/.github/scripts/sync_prds_to_wiki.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Publish versioned PRDs as deterministic GitHub Wiki pages."""
+"""Publish versioned PRDs as sections of one deterministic GitHub Wiki page."""
 
 from __future__ import annotations
 
@@ -25,6 +25,16 @@ def prd_slugs(source: Path) -> list[str]:
     )
 
 
+def demote_headings(content: str) -> str:
+    """Move source headings one level down so each PRD fits under the wiki page."""
+    return re.sub(
+        r"^(#{1,5})(\s+)",
+        lambda match: f"#{match.group(1)}{match.group(2)}",
+        content,
+        flags=re.MULTILINE,
+    )
+
+
 def publish(source: Path, wiki: Path, repository: str, ref: str) -> int:
     if not source.is_dir():
         raise FileNotFoundError(f"Diretório de PRDs não encontrado: {source}")
@@ -39,6 +49,7 @@ def publish(source: Path, wiki: Path, repository: str, ref: str) -> int:
         old_page.unlink()
 
     rows: list[str] = []
+    sections: list[str] = []
     for slug in slugs:
         if not SLUG_PATTERN.fullmatch(slug):
             raise ValueError(f"Slug inválido para página da wiki: {slug}")
@@ -56,29 +67,36 @@ def publish(source: Path, wiki: Path, repository: str, ref: str) -> int:
             f"https://github.com/{repository}/blob/{ref}/"
             f".codex/docs/specs/{slug}/prd.md"
         )
-        notice = (
-            "<!-- Página gerada automaticamente. Edite o PRD no repositório principal. -->\n\n"
-            f"> Documento publicado automaticamente a partir do "
-            f"[PRD versionado no repositório principal]({source_url}).\n\n"
+        sections.append(
+            "\n".join(
+                [
+                    "---",
+                    "",
+                    f'<a id="prd-{slug}"></a>',
+                    "",
+                    demote_headings(content),
+                    "",
+                    f"> Fonte: [PRD versionado no repositório principal]({source_url}).",
+                ]
+            )
         )
-        (wiki / f"PRD-{slug}.md").write_text(
-            notice + content + "\n", encoding="utf-8", newline="\n"
-        )
-        rows.append(f"| [{title}](PRD-{slug}) | {status} | {updated} |")
+        rows.append(f"| [{title}](#prd-{slug}) | {status} | {updated} |")
 
     index = "\n".join(
         [
             "# Product Requirements Document (PRD)",
             "",
             "Esta página reúne os documentos de requisitos do produto do LabOn. "
-            "As páginas são publicadas automaticamente a partir dos PRDs versionados "
+            "As seções são publicadas automaticamente a partir dos PRDs versionados "
             "no repositório principal.",
             "",
             "| PRD | Status | Atualizado em |",
             "| --- | --- | --- |",
             *rows,
             "",
-            "<!-- Índice gerado automaticamente. -->",
+            "<!-- Página gerada automaticamente. Edite os PRDs no repositório principal. -->",
+            "",
+            *sections,
             "",
         ]
     )

--- a/.github/workflows/publish-prds-wiki.yml
+++ b/.github/workflows/publish-prds-wiki.yml
@@ -1,0 +1,56 @@
+name: Publicar PRDs na Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".codex/docs/specs/**"
+      - ".github/scripts/sync_prds_to_wiki.py"
+      - ".github/workflows/publish-prds-wiki.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-prds-wiki
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    name: Sincronizar PRDs
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Obter repositório principal
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Clonar wiki
+        env:
+          WIKI_TOKEN: ${{ secrets.WIKI_TOKEN || github.token }}
+        run: git clone "https://x-access-token:${WIKI_TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" wiki
+
+      - name: Gerar páginas dos PRDs
+        run: >-
+          python .github/scripts/sync_prds_to_wiki.py
+          --source .codex/docs/specs
+          --wiki wiki
+          --repository "${GITHUB_REPOSITORY}"
+          --ref main
+
+      - name: Publicar alterações
+        working-directory: wiki
+        run: |
+          git add --all
+          if git diff --cached --quiet; then
+            echo "A wiki já está atualizada."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "docs: sincronizar PRDs"
+          git push origin HEAD:master

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 .env
 .env.prod
 .env.dev
+.codex/*
+!.codex/docs/
+.codex/docs/*
+!.codex/docs/specs/
+!.codex/docs/specs/**
+.codex/docs/specs/ordem.txt
+__pycache__/


### PR DESCRIPTION
## 📑 Tipo de mudança

<!-- Selecione UMA das opções abaixo -->
> Selecione **apenas uma** das opções abaixo, marcando com um `x`.

- [ ] novo-marco
- [ ] nova-feature-refactor
- [ ] bug-fix
- [x] outros

---

> ℹ️ A opção **"outros"** não gera nova tag de release.  
> 🛠️ **Preencha todos os campos de forma clara.** Este template é lido automaticamente pela nossa pipeline de CI/CD.

---

## 📝 Descrição

> Explique de forma objetiva **o que foi feito** neste PR, incluindo contexto, propósito da mudança e possíveis impactos.

Este PR versiona os 10 PRDs atuais e automatiza sua publicação na wiki do projeto. Os documentos são reunidos na página **Product Requirements Document (PRD)**, com uma tabela de navegação e cada PRD apresentado como uma seção interna. Apenas os títulos dos PRDs são exibidos no sumário lateral; contexto, escopo, requisitos e critérios permanecem disponíveis no conteúdo de cada seção.

O arquivo local `ordem.txt`, as skills e os demais arquivos pessoais de `.codex` continuam ignorados. Após mudanças nos PRDs chegarem à `main`, o workflow sincroniza automaticamente a página da wiki, utilizando `GITHUB_TOKEN` ou o secret opcional `WIKI_TOKEN` quando necessário.
