### PR TITLE
Automatizar métricas e itens do GitHub Project

### DIFF
--- a/.codex/skills/execute-task/SKILL.md
+++ b/.codex/skills/execute-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: execute-task
-description: Executar exatamente uma tarefa de um tasks.md no fluxo de Desenvolvimento Orientado por Especificações (SDD), implementando código com TDD e validando a esteira de testes. Usar quando o usuário indicar uma tarefa específica, pedir a próxima tarefa pronta ou solicitar implementação incremental sem orquestração. Respeitar escopo, dependências e caminhos sob responsabilidade; parar após uma única tarefa e registrar evidências RED-GREEN-REFACTOR.
+description: Executar exatamente uma tarefa de um tasks.md no fluxo de Desenvolvimento Orientado por Especificações (SDD), sincronizando a issue correspondente no GitHub Project, implementando código com TDD e validando a esteira de testes. Usar quando o usuário indicar uma tarefa específica, pedir a próxima tarefa pronta ou solicitar implementação incremental sem orquestração. Respeitar escopo, dependências e caminhos sob responsabilidade; parar após uma única tarefa e registrar evidências RED-GREEN-REFACTOR.
 ---
 
 # Executar uma tarefa
@@ -18,6 +18,17 @@ Ler `references/project-quality.md` antes de validar código neste repositório.
 3. Inspecionar `git status --short` e o diff relevante. Preservar alterações do usuário e não editar fora do escopo.
 4. Executar o teste direcionado existente ou a linha de base pertinente. Distinguir falha preexistente de regressão.
 5. Marcar a tarefa `em andamento`, salvo quando um orquestrador ordenar explicitamente que somente ele edite `tasks.md`.
+
+## Sincronização da issue e do Project
+
+Executar esta sincronização antes do RED. A solicitação para executar uma tarefa autoriza somente atribuir a issue correspondente e alterar o status do item dela no Project; não autoriza comentários, fechamento da issue nem outras mutações externas.
+
+1. Resolver a issue pela referência explícita na tarefa (`#<número>` ou URL). Se ela estiver ausente, herdar a referência do PRD somente quando houver exatamente uma issue relacionada. Com nenhuma ou várias candidatas, parar e solicitar uma associação inequívoca; nunca adivinhar.
+2. Confirmar que a issue pertence ao repositório atual. Obter o usuário autenticado com `gh api user --jq .login` e as configurações com `gh variable get PROJECT_OWNER --repo <owner/repo>` e `gh variable get PROJECT_NUMBER --repo <owner/repo>`. Nunca imprimir nem ler o valor de `PROJECT_TOKEN` durante uma execução local.
+3. Verificar se a issue está no Project configurado; adicioná-la se estiver ausente. Atribuí-la ao usuário autenticado, preservando responsáveis existentes, e alterar o campo `Status` do item para `In Progress`.
+4. Só iniciar implementação depois de validar no GitHub que o assignee e o status foram persistidos. Se autenticação, permissão, configuração ou atualização falhar, parar antes de editar código para evitar divergência entre tarefa e quadro.
+
+Na conclusão, manter `In Progress` quando a issue ainda tiver outras tarefas ou critérios pendentes. Alterar o item para `Done` somente quando esta for a última tarefa necessária e todos os critérios de aceitação da issue estiverem atendidos. Em caso de bloqueio, manter `In Progress` e relatar a causa. Nunca fechar a issue automaticamente.
 
 ## TDD obrigatório
 
@@ -52,4 +63,4 @@ Quando o usuário solicitar explicitamente branch, commit, push ou Pull Request:
 
 Marcar `concluída` somente com critérios atendidos e evidências RED/GREEN/REFACTOR, ou caracterização/verificação com falha inicial justificadas pelas exceções acima. Caso contrário, marcar `bloqueada` com causa acionável. Acrescentar uma linha ao log de execução, salvo sob controle do orquestrador.
 
-Ao terminar, informar: tarefa executada, arquivos alterados, evidência RED, comandos verdes, lacunas/preexistências e riscos restantes. Encerrar sem iniciar outra tarefa.
+Ao terminar, informar: tarefa e issue executadas, status final no Project, arquivos alterados, evidência RED, comandos verdes, lacunas/preexistências e riscos restantes. Encerrar sem iniciar outra tarefa.

--- a/.codex/skills/execute-task/agents/openai.yaml
+++ b/.codex/skills/execute-task/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Executar tarefa"
-  short_description: "Executa exatamente uma tarefa usando TDD"
-  default_prompt: "Use $execute-task para implementar uma única tarefa do plano com TDD e validações."
+  short_description: "Executa uma tarefa com TDD e sincroniza sua issue"
+  default_prompt: "Use $execute-task para implementar uma única tarefa com TDD e manter a issue correspondente sincronizada no GitHub Project."

--- a/.github/scripts/sync_github_project.py
+++ b/.github/scripts/sync_github_project.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Synchronize LabOn work items and metrics with a GitHub Project."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+
+METRICS_START = "<!-- METRICS:START -->"
+METRICS_END = "<!-- METRICS:END -->"
+
+PRD_BY_LABEL = {
+    "prd:autenticacao": "Ciclo de vida de autenticação e credenciais",
+    "prd:usuarios": "Cadastro e contratos de dados de usuário",
+    "prd:erros-frontend": "Experiência de erros no frontend",
+    "prd:responsividade": "Frontend responsivo",
+    "prd:qualidade": "Fundação de qualidade e testes críticos",
+    "prd:manual": "Manual de uso do LabOn",
+    "prd:conteineres": "Modernização da esteira de contêineres",
+    "prd:navegacao": "Navegação e experiência pós-autenticação",
+    "prd:dependencias": "Remediação de vulnerabilidades de dependências",
+    "prd:visibilidade": "Visibilidade e posicionamento de funcionalidades",
+}
+
+
+def run_gh(*args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if check and result.returncode != 0:
+        message = result.stderr.strip() or result.stdout.strip()
+        raise RuntimeError(f"gh {' '.join(args)}: {message}")
+    return result.stdout
+
+
+def gh_json(*args: str, check: bool = True) -> Any:
+    output = run_gh(*args, check=check).strip()
+    return json.loads(output) if output else None
+
+
+def gh_succeeds(*args: str) -> bool:
+    result = subprocess.run(
+        ["gh", *args],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def gh_json_optional(*args: str) -> Any | None:
+    result = subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    return json.loads(result.stdout)
+
+
+def normalized(value: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", value.lower())
+    return "".join(character for character in decomposed if not unicodedata.combining(character))
+
+
+def label_names(labels: list[Any]) -> list[str]:
+    return [label.get("name", "") if isinstance(label, dict) else str(label) for label in labels]
+
+
+def classify(title: str, labels: list[Any]) -> dict[str, str]:
+    names = label_names(labels)
+    searchable = normalized(" ".join([title, *names]))
+
+    if any(term in searchable for term in ("dependabot", "vulnerab", "secret scanning", "senha hardcoded")):
+        work_type = "Segurança"
+    elif any(term in searchable for term in ("workflow", "docker", "container", "ghcr", "azure", "devops")):
+        work_type = "DevOps"
+    elif any(term in searchable for term in ("document", "manual", "wiki")):
+        work_type = "Documentação"
+    elif any(term in searchable for term in ("teste", "quality", "qualidade", "maintainability", "reliability")):
+        work_type = "Qualidade"
+    elif any(term in searchable for term in ("corrigir", "erro", "bug", "falha", "invalido")):
+        work_type = "Bug"
+    else:
+        work_type = "Feature"
+
+    if any(term in searchable for term in ("workflow", "pipeline", "docker", "container", "ghcr", "azure", "ci/cd")):
+        area = "CI/CD"
+    elif any(term in searchable for term in ("frontend", "tela", "layout", "responsiv", "interface", "ux")):
+        area = "Frontend"
+    elif any(term in searchable for term in ("backend", "dto", "api", "seed")):
+        area = "Backend"
+    elif work_type == "Segurança":
+        area = "Segurança"
+    elif work_type == "Documentação":
+        area = "Documentação"
+    else:
+        area = "Produto"
+
+    if "critical" in searchable or "critica" in searchable or "crítica" in searchable:
+        priority, severity = "P0 Crítica", "Crítica"
+    elif work_type == "Segurança":
+        priority, severity = "P1 Alta", "Alta"
+    elif work_type in {"Bug", "Qualidade", "DevOps"}:
+        priority, severity = "P2 Média", "N/A"
+    else:
+        priority, severity = "P3 Baixa", "N/A"
+
+    prd = next((PRD_BY_LABEL[name] for name in names if name in PRD_BY_LABEL), "")
+    return {
+        "Tipo": work_type,
+        "Área": area,
+        "Prioridade": priority,
+        "Severidade": severity,
+        "PRD": prd,
+    }
+
+
+def replace_metrics_block(readme: str, metrics: list[str]) -> str:
+    block = "\n".join([METRICS_START, *metrics, METRICS_END])
+    pattern = re.compile(
+        rf"{re.escape(METRICS_START)}.*?{re.escape(METRICS_END)}",
+        flags=re.DOTALL,
+    )
+    if pattern.search(readme):
+        return pattern.sub(block, readme)
+    return readme.rstrip() + "\n\n## Indicadores atuais\n\n" + block + "\n"
+
+
+class ProjectSync:
+    def __init__(self, owner: str, number: int, repository: str, dry_run: bool = False):
+        self.owner = owner
+        self.number = number
+        self.repository = repository
+        self.dry_run = dry_run
+        self.project = gh_json("project", "view", str(number), "--owner", owner, "--format", "json")
+        self.project_id = self.project["id"]
+        field_data = gh_json("project", "field-list", str(number), "--owner", owner, "--format", "json")
+        self.fields = {field["name"]: field for field in field_data["fields"]}
+        self.refresh_items()
+
+    def refresh_items(self) -> None:
+        data = gh_json(
+            "project", "item-list", str(self.number), "--owner", self.owner,
+            "--limit", "500", "--format", "json",
+        )
+        self.items = {
+            item.get("content", {}).get("url"): item
+            for item in data["items"]
+            if item.get("content", {}).get("url")
+        }
+
+    def ensure_item(self, content: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
+        url = content["url"]
+        if url in self.items:
+            return self.items[url], False
+        if self.dry_run:
+            print(f"DRY-RUN adicionar item: {url}")
+            return None, True
+        item = gh_json(
+            "project", "item-add", str(self.number), "--owner", self.owner,
+            "--url", url, "--format", "json",
+        )
+        wrapped = {"id": item["id"], "content": content}
+        self.items[url] = wrapped
+        return wrapped, True
+
+    def set_select(self, item_id: str, field_name: str, option_name: str) -> None:
+        field = self.fields[field_name]
+        option = next(option for option in field["options"] if option["name"] == option_name)
+        if self.dry_run:
+            print(f"DRY-RUN {item_id}: {field_name}={option_name}")
+            return
+        run_gh(
+            "project", "item-edit", "--id", item_id, "--project-id", self.project_id,
+            "--field-id", field["id"], "--single-select-option-id", option["id"],
+        )
+
+    def set_text(self, item_id: str, field_name: str, value: str) -> None:
+        if not value:
+            return
+        if self.dry_run:
+            print(f"DRY-RUN {item_id}: {field_name}={value}")
+            return
+        run_gh(
+            "project", "item-edit", "--id", item_id, "--project-id", self.project_id,
+            "--field-id", self.fields[field_name]["id"], "--text", value,
+        )
+
+    def classify_new_item(self, item_id: str, content: dict[str, Any]) -> None:
+        values = classify(content.get("title", ""), content.get("labels", []))
+        for field_name in ("Tipo", "Área", "Prioridade", "Severidade"):
+            self.set_select(item_id, field_name, values[field_name])
+        self.set_text(item_id, "PRD", values["PRD"])
+
+    def sync_open_items(self) -> None:
+        issues = gh_json(
+            "issue", "list", "--repo", self.repository, "--state", "open", "--limit", "500",
+            "--json", "number,title,url,labels",
+        )
+        pulls = gh_json(
+            "pr", "list", "--repo", self.repository, "--state", "open", "--limit", "500",
+            "--json", "number,title,url,labels,isDraft",
+        )
+        for content in [*issues, *pulls]:
+            item, created = self.ensure_item(content)
+            if created and item:
+                self.set_select(item["id"], "Status", "Todo")
+                self.classify_new_item(item["id"], content)
+
+    def sync_event(self) -> None:
+        event_path = os.getenv("GITHUB_EVENT_PATH")
+        event_name = os.getenv("GITHUB_EVENT_NAME", "")
+        if not event_path or event_name not in {"issues", "pull_request_target"}:
+            return
+        with open(event_path, encoding="utf-8") as event_file:
+            payload = json.load(event_file)
+        content = payload.get("issue") or payload.get("pull_request")
+        if not content:
+            return
+        normalized_content = {
+            "number": content["number"],
+            "title": content["title"],
+            "url": content["html_url"],
+            "labels": content.get("labels", []),
+        }
+        item, created = self.ensure_item(normalized_content)
+        if not item:
+            return
+        if created:
+            self.classify_new_item(item["id"], normalized_content)
+        action = payload.get("action", "")
+        if action == "closed":
+            status = "Done"
+        elif action == "ready_for_review":
+            status = "In Progress"
+        elif action in {"opened", "reopened", "converted_to_draft"}:
+            status = "Todo"
+        else:
+            return
+        self.set_select(item["id"], "Status", status)
+
+    def metrics(self) -> list[str]:
+        issues = gh_json(
+            "issue", "list", "--repo", self.repository, "--state", "open", "--limit", "500",
+            "--json", "number,createdAt,labels,assignees",
+        )
+        now = datetime.now(timezone.utc)
+        ages = [
+            (now - datetime.fromisoformat(issue["createdAt"].replace("Z", "+00:00"))).total_seconds()
+            / 86_400
+            for issue in issues
+        ]
+        median_age = round(statistics.median(ages)) if ages else 0
+
+        alert_pages = gh_json_optional(
+            "api", "--paginate", "--slurp",
+            f"repos/{self.repository}/dependabot/alerts?per_page=100",
+        )
+        alerts = [alert for page in alert_pages for alert in page] if alert_pages else []
+        open_alerts = [alert for alert in alerts if alert.get("state") == "open"]
+        severity_counts = {name: 0 for name in ("critical", "high", "medium", "low")}
+        for alert in open_alerts:
+            severity = alert.get("security_advisory", {}).get("severity")
+            if severity in severity_counts:
+                severity_counts[severity] += 1
+
+        runs = gh_json_optional(
+            "api", f"repos/{self.repository}/actions/runs?per_page=100"
+        ) or {"workflow_runs": []}
+        conclusions = [
+            run.get("conclusion") for run in runs.get("workflow_runs", [])
+            if run.get("conclusion") not in {None, "skipped"}
+        ]
+        successes = conclusions.count("success")
+        success_rate = (successes / len(conclusions) * 100) if conclusions else 0
+        success_rate_text = f"{success_rate:.1f}".replace(".", ",")
+
+        protected = gh_succeeds(
+            "api", f"repos/{self.repository}/branches/develop/protection"
+        )
+        secret_scan = gh_succeeds(
+            "api", f"repos/{self.repository}/secret-scanning/alerts?per_page=1"
+        )
+        code_scan = gh_succeeds(
+            "api", f"repos/{self.repository}/code-scanning/alerts?per_page=1"
+        )
+        critical_label = "crítico" if severity_counts["critical"] == 1 else "críticos"
+        sao_paulo = timezone(timedelta(hours=-3))
+        local_date = now.astimezone(sao_paulo).date().isoformat()
+        if alert_pages is None:
+            dependabot_line = "- Alertas Dependabot abertos: indisponíveis para a credencial configurada"
+        else:
+            dependabot_line = (
+                "- Alertas Dependabot abertos: "
+                f"{len(open_alerts)} ({severity_counts['critical']} {critical_label}, "
+                f"{severity_counts['high']} altos, {severity_counts['medium']} médios e "
+                f"{severity_counts['low']} baixos)"
+            )
+
+        return [
+            f"- Issues abertas: {len(issues)}",
+            f"- Issues sem responsável: {sum(not issue['assignees'] for issue in issues)}",
+            f"- Issues sem classificação: {sum(not issue['labels'] for issue in issues)}",
+            f"- Idade mediana das issues abertas: {median_age} dias",
+            dependabot_line,
+            f"- Taxa recente de sucesso da CI: {success_rate_text}% "
+            f"({successes} sucessos em {len(conclusions)} execuções concluídas)",
+            f"- Proteção da branch `develop`: {'configurada' if protected else 'não configurada'}",
+            f"- Secret Scanning: {'habilitado' if secret_scan else 'desabilitado ou indisponível'}",
+            f"- Code Scanning: {'disponível' if code_scan else 'sem análise disponível pela API'}",
+            f"- Atualizado em: {local_date}",
+        ]
+
+    def update_metrics(self) -> None:
+        readme = self.project.get("readme", "")
+        updated = replace_metrics_block(readme, self.metrics())
+        if updated == readme:
+            print("Métricas já estão atualizadas.")
+            return
+        if self.dry_run:
+            print(updated)
+            return
+        run_gh(
+            "project", "edit", str(self.number), "--owner", self.owner,
+            "--readme", updated,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    owner = os.environ["PROJECT_OWNER"]
+    number = int(os.environ["PROJECT_NUMBER"])
+    repository = os.getenv("PROJECT_REPOSITORY", os.environ.get("GITHUB_REPOSITORY", ""))
+    if not repository:
+        raise RuntimeError("PROJECT_REPOSITORY ou GITHUB_REPOSITORY deve ser informado.")
+
+    sync = ProjectSync(owner, number, repository, args.dry_run)
+    sync.sync_open_items()
+    sync.sync_event()
+    sync.update_metrics()
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tests/test_sync_github_project.py
+++ b/.github/scripts/tests/test_sync_github_project.py
@@ -1,0 +1,48 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "sync_github_project.py"
+SPEC = importlib.util.spec_from_file_location("sync_github_project", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class ClassificationTests(unittest.TestCase):
+    def test_security_dependency_is_high_priority(self):
+        result = MODULE.classify("Corrigir vulnerabilidades do Dependabot", [])
+        self.assertEqual(result["Tipo"], "Segurança")
+        self.assertEqual(result["Área"], "Segurança")
+        self.assertEqual(result["Prioridade"], "P1 Alta")
+        self.assertEqual(result["Severidade"], "Alta")
+
+    def test_frontend_bug_is_classified(self):
+        result = MODULE.classify("Corrigir erro de layout no frontend", [])
+        self.assertEqual(result["Tipo"], "Bug")
+        self.assertEqual(result["Área"], "Frontend")
+        self.assertEqual(result["Prioridade"], "P2 Média")
+
+    def test_prd_label_sets_prd(self):
+        result = MODULE.classify("Adicionar alteração de senha", [{"name": "prd:autenticacao"}])
+        self.assertEqual(result["PRD"], "Ciclo de vida de autenticação e credenciais")
+
+
+class MetricsBlockTests(unittest.TestCase):
+    def test_replaces_existing_metrics_without_changing_surroundings(self):
+        readme = "Antes\n<!-- METRICS:START -->\nantigo\n<!-- METRICS:END -->\nDepois"
+        result = MODULE.replace_metrics_block(readme, ["- Novo: 1"])
+        self.assertEqual(
+            result,
+            "Antes\n<!-- METRICS:START -->\n- Novo: 1\n<!-- METRICS:END -->\nDepois",
+        )
+
+    def test_adds_metrics_when_markers_are_missing(self):
+        result = MODULE.replace_metrics_block("# Projeto\n", ["- Novo: 1"])
+        self.assertIn("## Indicadores atuais", result)
+        self.assertIn("- Novo: 1", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/project-metrics.yml
+++ b/.github/workflows/project-metrics.yml
@@ -1,0 +1,63 @@
+name: Sincronizar GitHub Project
+
+on:
+  issues:
+    types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]
+  pull_request_target:
+    branches:
+      - develop
+    types: [opened, reopened, closed, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
+  workflow_run:
+    workflows:
+      - CI/CD Workflow - Backend
+      - CI/CD Workflow - Frontend
+      - CodeQL
+    types: [completed]
+  schedule:
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+  security-events: read
+
+concurrency:
+  group: sync-github-project
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Atualizar itens e métricas
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
+      PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+      PROJECT_REPOSITORY: ${{ github.repository }}
+
+    steps:
+      - name: Verificar configuração
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          if [ -z "${PROJECT_TOKEN}" ]; then
+            echo "Configure o secret PROJECT_TOKEN com acesso ao GitHub Project."
+            exit 1
+          fi
+          if [ -z "${PROJECT_OWNER}" ] || [ -z "${PROJECT_NUMBER}" ]; then
+            echo "Configure as variáveis PROJECT_OWNER e PROJECT_NUMBER."
+            exit 1
+          fi
+
+      - name: Obter versão confiável da automação
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          persist-credentials: false
+
+      - name: Sincronizar Project
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: python .github/scripts/sync_github_project.py

--- a/README.md
+++ b/README.md
@@ -45,3 +45,7 @@ Visualizar o passo a passo em: [Fluxo de Contribuição](https://github.com/ifpe
 ## Wiki
 Para mais informações e documentação do projeto, acesse nossa [Wiki](https://github.com/ifpebj-ti/lab-solos/wiki).
 
+## Gestão do Projeto
+
+O desenvolvimento, a qualidade e os indicadores do LabOn são acompanhados no [GitHub Project — LabOn: Desenvolvimento e Qualidade](https://github.com/users/nathannmvr/projects/4).
+


### PR DESCRIPTION
## 📑 Tipo de mudança

<!-- Selecione UMA das opções abaixo -->
> Selecione **apenas uma** das opções abaixo, marcando com um `x`.

- [ ] novo-marco
- [x] nova-feature-refactor
- [ ] bug-fix
- [ ] outros

---

> ℹ️ A opção **outros** não gera nova tag de release.  
> 🛠️ **Preencha todos os campos de forma clara.** Este template é lido automaticamente pela nossa pipeline de CI/CD.

---

## 📝 Descrição

> Explique de forma objetiva **o que foi feito** neste PR, incluindo contexto, propósito da mudança e possíveis impactos.

Este PR adiciona a automação do GitHub Project pessoal **LabOn — Desenvolvimento e Qualidade**. O workflow sincroniza issues e pull requests, atualiza o status conforme o ciclo de vida dos itens e recalcula métricas de backlog, CI e segurança no README do Project.

Também foram incluídos testes unitários para as regras de classificação e para a atualização segura do bloco de indicadores. A automação usa sempre a versão confiável presente na branch `develop`; as variáveis `PROJECT_OWNER`, `PROJECT_NUMBER` e o secret `PROJECT_TOKEN` já estão configurados no repositório.

O README principal passa a oferecer acesso direto ao Project, enquanto o README do Project aponta de volta para o repositório.