### PR TITLE
bugfix/project: manter apenas issues no Project

### DIFF
--- a/.github/scripts/sync_github_project.py
+++ b/.github/scripts/sync_github_project.py
@@ -159,11 +159,31 @@ class ProjectSync:
             "project", "item-list", str(self.number), "--owner", self.owner,
             "--limit", "500", "--format", "json",
         )
+        self.project_items = data["items"]
         self.items = {
             item.get("content", {}).get("url"): item
-            for item in data["items"]
+            for item in self.project_items
             if item.get("content", {}).get("url")
         }
+
+    def remove_non_issue_items(self) -> None:
+        removed = False
+        for item in self.project_items:
+            if item.get("content", {}).get("type") == "Issue":
+                continue
+            item_id = item.get("id")
+            if not item_id:
+                continue
+            if self.dry_run:
+                print(f"DRY-RUN remover item não-Issue: {item_id}")
+            else:
+                run_gh(
+                    "project", "item-delete", str(self.number), "--owner", self.owner,
+                    "--id", item_id,
+                )
+            removed = True
+        if removed and not self.dry_run:
+            self.refresh_items()
 
     def ensure_item(self, content: dict[str, Any]) -> tuple[dict[str, Any] | None, bool]:
         url = content["url"]
@@ -213,11 +233,7 @@ class ProjectSync:
             "issue", "list", "--repo", self.repository, "--state", "open", "--limit", "500",
             "--json", "number,title,url,labels",
         )
-        pulls = gh_json(
-            "pr", "list", "--repo", self.repository, "--state", "open", "--limit", "500",
-            "--json", "number,title,url,labels,isDraft",
-        )
-        for content in [*issues, *pulls]:
+        for content in issues:
             item, created = self.ensure_item(content)
             if created and item:
                 self.set_select(item["id"], "Status", "Todo")
@@ -226,11 +242,11 @@ class ProjectSync:
     def sync_event(self) -> None:
         event_path = os.getenv("GITHUB_EVENT_PATH")
         event_name = os.getenv("GITHUB_EVENT_NAME", "")
-        if not event_path or event_name not in {"issues", "pull_request_target"}:
+        if not event_path or event_name != "issues":
             return
         with open(event_path, encoding="utf-8") as event_file:
             payload = json.load(event_file)
-        content = payload.get("issue") or payload.get("pull_request")
+        content = payload.get("issue")
         if not content:
             return
         normalized_content = {
@@ -353,6 +369,7 @@ def main() -> None:
         raise RuntimeError("PROJECT_REPOSITORY ou GITHUB_REPOSITORY deve ser informado.")
 
     sync = ProjectSync(owner, number, repository, args.dry_run)
+    sync.remove_non_issue_items()
     sync.sync_open_items()
     sync.sync_event()
     sync.update_metrics()

--- a/.github/scripts/tests/test_sync_github_project.py
+++ b/.github/scripts/tests/test_sync_github_project.py
@@ -1,6 +1,9 @@
 import importlib.util
+import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 
 SCRIPT = Path(__file__).parents[1] / "sync_github_project.py"
@@ -42,6 +45,87 @@ class MetricsBlockTests(unittest.TestCase):
         result = MODULE.replace_metrics_block("# Projeto\n", ["- Novo: 1"])
         self.assertIn("## Indicadores atuais", result)
         self.assertIn("- Novo: 1", result)
+
+
+class IssueOnlySyncTests(unittest.TestCase):
+    def make_sync(self):
+        sync = MODULE.ProjectSync.__new__(MODULE.ProjectSync)
+        sync.owner = "owner"
+        sync.number = 4
+        sync.repository = "owner/repository"
+        sync.dry_run = False
+        sync.project_id = "project-id"
+        sync.fields = {}
+        sync.project_items = []
+        sync.items = {}
+        return sync
+
+    def test_sync_open_items_queries_only_issues(self):
+        sync = self.make_sync()
+        issue = {
+            "number": 236,
+            "title": "Corrigir vulnerabilidades",
+            "url": "https://github.com/owner/repository/issues/236",
+            "labels": [],
+        }
+
+        with (
+            patch.object(MODULE, "gh_json", return_value=[issue]) as gh_json,
+            patch.object(sync, "ensure_item", return_value=(None, True)) as ensure_item,
+        ):
+            sync.sync_open_items()
+
+        gh_json.assert_called_once()
+        self.assertEqual(gh_json.call_args.args[:2], ("issue", "list"))
+        ensure_item.assert_called_once_with(issue)
+
+    def test_remove_non_issue_items_preserves_issues_and_removes_pull_requests(self):
+        sync = self.make_sync()
+        sync.project_items = [
+            {"id": "issue-item", "content": {"type": "Issue"}},
+            {"id": "pr-item", "content": {"type": "PullRequest"}},
+            {"id": "draft-item", "content": {"type": "DraftIssue"}},
+        ]
+
+        with (
+            patch.object(MODULE, "run_gh") as run_gh,
+            patch.object(sync, "refresh_items") as refresh_items,
+        ):
+            sync.remove_non_issue_items()
+
+        self.assertEqual(
+            [call.args[-1] for call in run_gh.call_args_list],
+            ["pr-item", "draft-item"],
+        )
+        refresh_items.assert_called_once_with()
+
+    def test_pull_request_event_is_ignored(self):
+        sync = self.make_sync()
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            event_path = Path(temporary_directory) / "event.json"
+            event_path.write_text(
+                '{"pull_request":{"number":244,"title":"PR","html_url":"https://example/pr"}}',
+                encoding="utf-8",
+            )
+            with (
+                patch.dict(
+                    os.environ,
+                    {"GITHUB_EVENT_PATH": str(event_path), "GITHUB_EVENT_NAME": "pull_request_target"},
+                ),
+                patch.object(sync, "ensure_item") as ensure_item,
+            ):
+                sync.sync_event()
+
+        ensure_item.assert_not_called()
+
+
+class WorkflowTests(unittest.TestCase):
+    def test_workflow_does_not_subscribe_to_pull_requests(self):
+        workflow = (SCRIPT.parents[1] / "workflows" / "project-metrics.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn("pull_request_target:", workflow)
+        self.assertNotIn("pull-requests: read", workflow)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/project-metrics.yml
+++ b/.github/workflows/project-metrics.yml
@@ -3,10 +3,6 @@ name: Sincronizar GitHub Project
 on:
   issues:
     types: [opened, reopened, closed, labeled, unlabeled, assigned, unassigned]
-  pull_request_target:
-    branches:
-      - develop
-    types: [opened, reopened, closed, synchronize, ready_for_review, converted_to_draft, labeled, unlabeled]
   workflow_run:
     workflows:
       - CI/CD Workflow - Backend
@@ -21,7 +17,6 @@ permissions:
   actions: read
   contents: read
   issues: read
-  pull-requests: read
   security-events: read
 
 concurrency:


### PR DESCRIPTION
## 📑 Tipo de mudança

<!-- Selecione UMA das opções abaixo -->
> Selecione **apenas uma** das opções abaixo, marcando com um `x`.

- [ ] novo-marco
- [ ] nova-feature-refactor
- [x] bug-fix
- [ ] outros

---

> ℹ️ A opção **outros** não gera nova tag de release.  
> 🛠️ **Preencha todos os campos de forma clara.** Este template é lido automaticamente pela nossa pipeline de CI/CD.

---

## 📝 Descrição

Corrige a sincronização do GitHub Project para manter exclusivamente conteúdos do tipo Issue.

A mudança:
- remove o gatilho `pull_request_target` e a permissão de leitura de Pull Requests;
- deixa de consultar ou adicionar PRs durante a reconciliação;
- ignora eventos de Pull Request no script;
- remove do Project vínculos existentes cujo conteúdo não seja uma Issue, sem fechar ou apagar o conteúdo original;
- preserva a sincronização, classificação e métricas das Issues.

Validação:
- 9/9 testes direcionados;
- 37/37 testes Python amplos;
- workflow formatado com Prettier;
- dry-run confirmou 13 Pull Requests existentes como únicos alvos de limpeza.