### PR TITLE
docs: adicionar apresentação semanal do LabOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ Para mais informações e documentação do projeto, acesse nossa [Wiki](https:/
 
 O desenvolvimento, a qualidade e os indicadores do LabOn são acompanhados no [GitHub Project — LabOn: Desenvolvimento e Qualidade](https://github.com/users/nathannmvr/projects/4).
 
+## Apresentações semanais
+
+Os reports semanais do projeto estão disponíveis em [LabOn Presentation](https://lab-on-presentation.vercel.app/).
+


### PR DESCRIPTION
## Resumo

- adiciona ao README o acesso à apresentação semanal do LabOn
- aponta para a implantação hospedada na Vercel

## Validação

- link verificado com resposta HTTP 200
- alteração restrita ao README.md